### PR TITLE
fix(security): correct broken authorization logic in user middleware

### DIFF
--- a/myojana/middlewares/user.py
+++ b/myojana/middlewares/user.py
@@ -2,7 +2,7 @@ import frappe
 def list_query(user):
     if not user:
         user = frappe.session.user
-    if "Administrator" and "Admin" not in frappe.get_roles(user):
-        profile_condition = f"""(`tabUser`.name = '{user}')"""
-        return profile_condition
+    if "Administrator" not in frappe.get_roles(user) and "Admin" not in frappe.get_roles(user):
+        profile_condition = frappe.db.escape(user)
+        return f"(`tabUser`.name = {profile_condition})"
 


### PR DESCRIPTION
## Summary
- Fix `if "Administrator" and "Admin" not in roles` which always evaluated to `True` due to truthy string
- Corrected to `if "Administrator" not in roles and "Admin" not in roles`
- Also escape the user value in the SQL condition

## Files Changed
- `myojana/middlewares/user.py`

Closes #2

https://claude.ai/code/session_01MSMFLShjUcBdDw6jgAB6PR