### PR TITLE
fix(security): require authentication on all sensitive API endpoints

### DIFF
--- a/myojana/api.py
+++ b/myojana/api.py
@@ -7,7 +7,7 @@ import json
 
 from myojana.utils.htmltoimg import create_image
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_image(ben_id):
     return create_image(ben_id)
 
@@ -15,7 +15,7 @@ def get_image(ben_id):
 def get_mYojana_settings():
     return frappe.get_doc('mYojana Settings')
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_installed_apps():
     installed_apps = frappe.get_installed_apps()
     return installed_apps
@@ -145,11 +145,11 @@ def get_total_beneficiary_count_query(scheme_doc , start=0,page_limit=10,filters
     """
             # LIMIT {page_limit} OFFSET {start}
     return sql
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def execute(name=None):
     return BeneficaryScheme.get_schemes(name)
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def eligible_beneficiaries(scheme=None, columns=[], filters=[], start=0, page_imit=10,is_limit=False):
     # filter value is getting hear
     # print("filter", filters)
@@ -187,7 +187,7 @@ def eligible_beneficiaries(scheme=None, columns=[], filters=[], start=0, page_im
         res['count'].update(count_data[0])
     return res
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def most_eligible_ben():
     scheam_ben_count =[]
     scheame_query = f"""select name  from `tabScheme` """
@@ -213,7 +213,7 @@ def most_eligible_ben():
     top_5_schemes = sorted_schemes[:5]
     return top_5_schemes
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def top_schemes():
     milestones = frappe.get_list("Milestone category", fields=['name'])
     # user_role_filter = Filter.set_query_filters()

--- a/myojana/apis/html_to_image.py
+++ b/myojana/apis/html_to_image.py
@@ -23,7 +23,7 @@ def file_to_base64(file_path):
     with open(file_path, "rb") as file:
         return base64.b64encode(file.read()).decode('utf-8')
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def create_image(ref_doc, tepmlate_name):
     template = frappe.get_doc("App Template", tepmlate_name)
     context,doc = set_context_data(template.ref_doctype,ref_doc)
@@ -63,7 +63,7 @@ def set_context_data(doctype, name):
                     base64_data =  f"data:image/png;base64,{file_to_base64(file_path)}"
                     doc.set(field, base64_data)
     return doc.as_dict(),doc
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def preview_image(doctype, doc, template, options=None):
     context, doc = set_context_data(doctype,doc)
     # return template, context
@@ -86,7 +86,7 @@ def preview_image(doctype, doc, template, options=None):
     image_binary = imgkit.from_string(processed_html, False, options=options)
     return base64.b64encode(image_binary).decode('utf-8')
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def preview_doc_template(doc):
     template_name = frappe.db.get_single_value('mYojana Settings', 'id_card_template')
     if not template_name:


### PR DESCRIPTION
## Summary
- Remove `allow_guest=True` from 9 endpoints that expose beneficiary PII, scheme data, or system info
- Only `get_mYojana_settings()` retains guest access for public configuration

## Files Changed
- `myojana/api.py` — get_image, get_installed_apps, execute, eligible_beneficiaries, most_eligible_ben, top_schemes
- `myojana/apis/html_to_image.py` — create_image, preview_image, preview_doc_template

Closes #3

https://claude.ai/code/session_01MSMFLShjUcBdDw6jgAB6PR