### PR TITLE
fix(bug): resolve typos, invalid syntax, division-by-zero, and bare excepts

### DIFF
--- a/myojana/api.py
+++ b/myojana/api.py
@@ -1,5 +1,5 @@
 import frappe
-from myojana.services.beneficiary_scheme import BeneficaryScheme
+from myojana.services.beneficiary_scheme import BeneficiaryScheme
 from myojana.utils.misc import Misc
 # from myojana.utils.filter import Filter
 from myojana.utils.report_filter import ReportFilter
@@ -22,7 +22,7 @@ def get_installed_apps():
 
 def create_condition(scheme, _tbl_pre=""):
     if isinstance(scheme, str):
-        raise "No rules"
+        raise frappe.ValidationError("No rules defined for this scheme")
     user_role_filter = ReportFilter.set_report_filters()
     cond_str = Misc.create_condition(scheme.rules)
     filters = []
@@ -147,7 +147,7 @@ def get_total_beneficiary_count_query(scheme_doc , start=0,page_limit=10,filters
     return sql
 @frappe.whitelist(allow_guest=True)
 def execute(name=None):
-    return BeneficaryScheme.get_schemes(name)
+    return BeneficiaryScheme.get_schemes(name)
 
 @frappe.whitelist(allow_guest=True)
 def eligible_beneficiaries(scheme=None, columns=[], filters=[], start=0, page_imit=10,is_limit=False):

--- a/myojana/apis/html_to_image.py
+++ b/myojana/apis/html_to_image.py
@@ -29,8 +29,8 @@ def create_image(ref_doc, tepmlate_name):
     context,doc = set_context_data(template.ref_doctype,ref_doc)
     try:
         options = json.loads(options)
-    except:
-        options = None    
+    except (json.JSONDecodeError, TypeError):
+        options = None
     if not options:
         options = {
             'width': 547,
@@ -76,8 +76,8 @@ def preview_image(doctype, doc, template, options=None):
     
     try:
         options = json.loads(options)
-    except:
-        options = None    
+    except (json.JSONDecodeError, TypeError):
+        options = None
     if not options:
         options = {
             'width': 547,

--- a/myojana/services/beneficiary_scheme.py
+++ b/myojana/services/beneficiary_scheme.py
@@ -1,6 +1,6 @@
 import frappe
 from myojana.utils.misc import Misc
-class BeneficaryScheme:
+class BeneficiaryScheme:
     def run(beneficiary=None):
         schemes = frappe.get_list('Scheme', fields=['name', 'name_of_department', 'milestone'])
         for scheme in schemes:
@@ -26,7 +26,7 @@ class BeneficaryScheme:
             scheme['total_rules'] = len(rule_list)
             scheme['matching_rules'] = matching_counter
             scheme['matching_rules_per'] = 0
-            if matching_counter > 0:
+            if matching_counter > 0 and scheme['total_rules'] > 0:
                 scheme['matching_rules_per'] = (matching_counter/scheme['total_rules'])*100
         return schemes
     def validate(beneficiary, condition):
@@ -89,7 +89,7 @@ class BeneficaryScheme:
                 scheme['total_rules'] = percentage_sorted_list[0]['total'] if len(percentage_sorted_list)>0 else 0
                 scheme['matching_rules'] = percentage_sorted_list[0]['matched'] if len(percentage_sorted_list)>0 else 0
                 scheme['matching_rules_per'] = 0
-                if scheme['matching_rules'] > 0:
+                if scheme['matching_rules'] > 0 and scheme['total_rules'] > 0:
                     scheme['matching_rules_per'] = ((scheme['matching_rules']/scheme['total_rules'])*100)
         res_schemes_denominator_sort = sorted(schemes, key=lambda x: x.get('total_rules', 0), reverse=True)
         res_schemes = sorted(res_schemes_denominator_sort, key=lambda x: x.get('matching_rules_per', 0), reverse=True)

--- a/myojana/services/family.py
+++ b/myojana/services/family.py
@@ -57,6 +57,6 @@ class family:
                     # print("_doc_before_save[IF->IF->IF] del_doc",del_doc)
 
     def delete_family(beneficiary):
-        delate_family = frappe.db.delete("Primary Member", {
+        result = frappe.db.delete("Primary Member", {
                         "name": beneficiary.contact_number})
-        return delate_family
+        return result


### PR DESCRIPTION
## Summary
- Fix invalid `raise "No rules"` → `raise frappe.ValidationError(...)`
- Rename class `BeneficaryScheme` → `BeneficiaryScheme` (missing 'i')
- Fix local variable typo `delate_family` → `result`
- Guard division-by-zero in `matching_rules_per` calculations
- Replace bare `except:` with `except (json.JSONDecodeError, TypeError):`

## Files Changed
- `myojana/api.py`
- `myojana/services/beneficiary_scheme.py`
- `myojana/services/family.py`
- `myojana/apis/html_to_image.py`

Closes #5 #6 #7 #8

https://claude.ai/code/session_01MSMFLShjUcBdDw6jgAB6PR