### PR TITLE
fix(code-quality): remove print statements, dead code, and harden load_test

### DIFF
--- a/myojana/apis/html_to_image.py
+++ b/myojana/apis/html_to_image.py
@@ -43,7 +43,6 @@ def create_image(ref_doc, tepmlate_name):
         file = save_file(f"{doc.name}.png", image_binary, template.ref_doctype, doc.name, folder=None, decode=False, is_private=0, df=None)
         return file,doc
     except Exception as e:
-        print("Exception::",e)
         frappe.log_error(f"Error in rendering template: {e}", "Check Syntax")
         return None,None
     
@@ -70,7 +69,6 @@ def preview_image(doctype, doc, template, options=None):
     try:
         processed_html = render_template(template, context)
     except Exception as e:
-        print("Exception::",e)
         frappe.log_error(f"Error in rendering template: {e}", "Check Syntax")
         return None
     
@@ -91,7 +89,6 @@ def preview_doc_template(doc):
     template_name = frappe.db.get_single_value('mYojana Settings', 'id_card_template')
     if not template_name:
         frappe.throw(_("Please set ID Card Template in mYojana Settings"))
-    print("template_name",template_name)
     template = frappe.get_doc('App Template', template_name)
     if not template:
         frappe.throw(_("Please set ID Card Template in Whats App Template"))

--- a/myojana/apis/load_test.py
+++ b/myojana/apis/load_test.py
@@ -207,11 +207,13 @@ def generate_random_bulk_data():
     return data
 @frappe.whitelist()
 def create_beneficiary_profiling(count=10):
-    if frappe.session.user == "Administrator":
-        for _ in range(count):
-            beneficiary = frappe.new_doc("Beneficiary Profiling")
-            beneficiary.update(generate_random_bulk_data())
-            beneficiary.insert()
-        return count
-    else:
-        return "Invalid access to the api!"
+    if not frappe.conf.developer_mode:
+        frappe.throw("This API is only available in developer mode")
+    if "Administrator" not in frappe.get_roles(frappe.session.user):
+        frappe.throw("Access denied")
+    count = min(int(count), 100)  # cap at 100 to prevent DoS
+    for _ in range(count):
+        beneficiary = frappe.new_doc("Beneficiary Profiling")
+        beneficiary.update(generate_random_bulk_data())
+        beneficiary.insert()
+    return count

--- a/myojana/apis/whatsapp.py
+++ b/myojana/apis/whatsapp.py
@@ -38,7 +38,7 @@ def test_auth_key(auth_key):
 def send_id(doc):
     template_name, auth_key , integrated_number = frappe.db.get_value('mYojana Settings', None, ['id_card_template', 'auth_key' ,'integrated_number'])
 
-    print("template_name",auth_key)
+    # auth_key intentionally not logged
     if not auth_key:
         frappe.throw(_("Please set Auth Key in mYojana Settings"))
 
@@ -87,7 +87,6 @@ def send_id(doc):
     conn.request("POST", "/api/v5/whatsapp/whatsapp-outbound-message/bulk/", payload, headers)
     res = conn.getresponse()
     data = res.read()
-    print(data.decode("utf-8"))
     return data.decode("utf-8")
 
 @frappe.whitelist()
@@ -106,5 +105,4 @@ def send(phoneNo):
     conn.request("POST", "/wa/api/v1/msg", payload, headers)
     res = conn.getresponse()
     data = res.read()
-    print("///////////////////////////////////////////////////////", data)
     return json.loads(data.decode("utf-8"))

--- a/myojana/utils/report_filter.py
+++ b/myojana/utils/report_filter.py
@@ -40,14 +40,8 @@ class ReportFilter:
                     new_filters[filter_key] = filters[filter_key]
 
         if role_per_filter and ("Administrator" not in frappe.get_roles(frappe.session.user)):
-            per_obj = Cache.get_user_permission(False)
-        #     # query_filter = Filter.set_query_filters(True)
-            # csc_key = f"{table_name}.{query_filter[0]}" if table_name else  f"{query_filter[0]}"
             if str and len(cond_str) > 0:
                 str_list.append(cond_str)
-            else:
-                ""
-                # new_filters[csc_key] = f"'{query_filter[1]}'"
         if str:
             return ' AND '.join(str_list)
         else:


### PR DESCRIPTION
## Summary
- Remove `print()` that leaked auth_key and logged raw API responses
- Remove unused `per_obj` variable and dead commented-out code in report_filter.py
- Add `developer_mode` guard to load_test.py, replace username equality check with role check, cap `count` at 100

## Files Changed
- `myojana/apis/whatsapp.py`
- `myojana/apis/html_to_image.py`
- `myojana/utils/report_filter.py`
- `myojana/apis/load_test.py`

Closes #9 #10 #11

https://claude.ai/code/session_01MSMFLShjUcBdDw6jgAB6PR