### PR TITLE
perf: add DB indexes on key fields and fix scheduler duplication

### DIFF
--- a/myojana/myojana/doctype/beneficiary_profiling/beneficiary_profiling.json
+++ b/myojana/myojana/doctype/beneficiary_profiling/beneficiary_profiling.json
@@ -89,7 +89,8 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Date of registration",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "name_of_the_beneficiary",
@@ -112,7 +113,8 @@
    "fieldname": "date_of_birth",
    "fieldtype": "Date",
    "label": "Date of birth",
-   "mandatory_depends_on": "eval:!(doc.is_bulk_imported == 1 && doc.__islocal)"
+   "mandatory_depends_on": "eval:!(doc.is_bulk_imported == 1 && doc.__islocal)",
+   "search_index": 1
   },
   {
    "fieldname": "completed_age",
@@ -243,14 +245,16 @@
    "fieldtype": "Link",
    "label": "State",
    "mandatory_depends_on": "eval:!(doc.is_bulk_imported == 1 && doc.__islocal)",
-   "options": "State"
+   "options": "State",
+   "search_index": 1
   },
   {
    "fieldname": "district",
    "fieldtype": "Link",
    "label": "District",
    "mandatory_depends_on": "eval:!(doc.is_bulk_imported == 1 && doc.__islocal)",
-   "options": "District"
+   "options": "District",
+   "search_index": 1
   },
   {
    "fieldname": "column_break_hspz",
@@ -354,7 +358,8 @@
    "in_list_view": 1,
    "label": "Select primary member",
    "mandatory_depends_on": "eval:doc.has_anyone_from_your_family_visisted_before == \"Yes\"",
-   "options": "Primary Member"
+   "options": "Primary Member",
+   "search_index": 1
   },
   {
    "fieldname": "scheme_tab",

--- a/myojana/scheduler_events/ben_dob_update.py
+++ b/myojana/scheduler_events/ben_dob_update.py
@@ -1,31 +1,24 @@
 import frappe
 
 def update_age():
+    # TIMESTAMPDIFF(YEAR,...) already handles the birthday-month/day comparison
+    # correctly, so both CASE branches are identical — simplified here.
     query = """
         UPDATE
             `tabBeneficiary Profiling`
         SET
-            completed_age = (
-                CASE
-                    WHEN MONTH(CURDATE()) < MONTH(date_of_birth) OR (MONTH(CURDATE()) = MONTH(date_of_birth) AND DAY(CURDATE()) < DAY(date_of_birth)) THEN TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE())
-                    ELSE TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE())
-            END
-            ),
-            completed_age_month = (TIMESTAMPDIFF(MONTH, date_of_birth, CURDATE()) % 12)
+            completed_age = TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()),
+            completed_age_month = TIMESTAMPDIFF(MONTH, date_of_birth, CURDATE()) %% 12
         WHERE
-            completed_age != (
-                CASE
-                    WHEN MONTH(CURDATE()) < MONTH(date_of_birth) OR (MONTH(CURDATE()) = MONTH(date_of_birth) AND DAY(CURDATE()) < DAY(date_of_birth)) THEN TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE())
-                    ELSE TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE())
-                END
-            )
-            OR
-            completed_age_month != (TIMESTAMPDIFF(MONTH, date_of_birth, CURDATE()) % 12);
+            completed_age != TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE())
+            OR completed_age_month != TIMESTAMPDIFF(MONTH, date_of_birth, CURDATE()) %% 12
     """
     try:
-        data = frappe.db.sql(query, as_dict=True)
+        frappe.db.sql(query)
+        frappe.db.commit()
+        frappe.logger().info("ben_dob_update: update_age completed successfully")
     except Exception as e:
-        frappe.throw(str(e))
+        frappe.log_error(f"ben_dob_update.update_age failed: {e}", "Scheduler Error")
 
 def update_dob_of_ben():
     query = """UPDATE `tabBeneficiary Profiling`


### PR DESCRIPTION
## Summary
- Add `search_index: 1` on `date_of_visit`, `date_of_birth`, `state`, `district`, `select_primary_member` in `beneficiary_profiling.json` — these fields appear in WHERE/JOIN clauses of all 39 reports and core APIs
- Deduplicate identical CASE branches in `ben_dob_update.py` scheduler; add success logging and error capture

## Files Changed
- `myojana/myojana/doctype/beneficiary_profiling/beneficiary_profiling.json`
- `myojana/scheduler_events/ben_dob_update.py`

Closes #12 #15

https://claude.ai/code/session_01MSMFLShjUcBdDw6jgAB6PR